### PR TITLE
Add Github secret option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+#    Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/.ipynb_checkpoints/
+*.py[cod]
+*.pyc
+*.pyo
+*.so
+
+# Mkdocs
+build/
+site/
+
+# pip package
+dist/
+*.egg-info/
+
+# Vscode
+.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Pipenv
+Pipfile
+Pipfile.lock
+
+# Data not intended for deployment
+**.m
+**.pt
+**/logs
+# **notebooks**
+
+# Test & Backups
+*test*.py
+**test**

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ If a password is defined in an article, it will **ALWAYS** overwrite the global 
 
 ### Github secret
 
-Instead of specifying a password in the mkdocs.yml file, you can use a Github secret alongswide with a Github worflow action.
+Instead of specifying a password in the mkdocs.yml file, you can use a Github secret coupled to a Github worflow action.
 This requires a requirements.txt in order to install everything required to build the docs.
 
-1. Go to the repo containing the doc you want to protect. Then go to Settings > Secrets > Actions > New repository secret.
-2. Name the secret PASSWORD and specify the the secret value you want to use.
-3. Go to Actions > New worklow > set up a workflow yourself and write the following in the yaml file (name it as you like and take care
+1. Go to the repo containing the doc you want to protect. Then go to `Settings > Secrets > Actions > New repository secret`.
+2. Name the secret `PASSWORD` and specify the the secret value you want to use.
+3. Go to `Actions > New workflow > set up a workflow yourself` and write the following in the yaml file (name it as you like and take care
 of the requirements.txt path):
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -87,47 +87,17 @@ If a password is defined in an article, it will **ALWAYS** overwrite the global 
 
 ### Github secret
 
-Instead of specifying a password in the mkdocs.yml file, you can use a Github secret coupled to a Github worflow action.
-This requires a requirements.txt in order to install everything required to build the docs.
+Instead of specifying a password in the mkdocs.yml file, you can use a Github secret coupled to a CI/CD pipeline. This process is in two steps:
 
-1. Go to the repo containing the doc you want to protect. Then go to `Settings > Secrets > Actions > New repository secret`.
-2. Name the secret `PASSWORD` and specify the the secret value you want to use.
-3. Go to `Actions > New workflow > set up a workflow yourself` and write the following in the yaml file (name it as you like and take care
-of the requirements.txt path):
+1. First, you need to make an environment variable containing your password accessible at runtime (through any CI/CD pipeline). 
 
-```yaml
-name: ci 
 
-on:
-  push:
-    branches:
-      - main
-
-env:
-  PASSWORD: "${{ secrets.PASSWORD }}"
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v3.0.2
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - name: Deploy
-        run: |
-          pip install -r ./docs/requirements.txt 
-          mkdocs gh-deploy --force
-```
-
-4. Finally, in the mkdocs.yml file, instead of specifying a global password, simply put the `use_secret` field to true:
+4. Finally, in the mkdocs.yml file, instead of specifying a global password, simply set the `use_secret` field to the name of your environment variable, e.g. in the case where my secret is stored in the $PASSWORD` variable:
 
 ```yaml
 plugins:
     - encryptcontent:
-        use_secret: true
+        use_secret: 'PASSWORD'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The content is encrypted with AES-256 in Python using PyCryptodome, and decrypte
   * [Installation](#installation)
   * [Usage](#usage)
     * [Global password protection](#global-password-protection)
+    * [Github secret](#github-secret)
     * [Customization](#extra-vars-customization)
   * [Features](#features)
     * [HighlightJS support](#highlightjs-support) *(default)*
@@ -68,6 +69,7 @@ plugins:
 
 Add an meta tag `password: secret_password` in your markdown files to protect them.
 
+
 ### Global password protection
 
 Add `global_password: your_password` in plugin configuration variable, to protect by default your articles with this password
@@ -81,6 +83,53 @@ plugins:
 If a password is defined in an article, it will **ALWAYS** overwrite the global password. 
 
 > **NOTE** Keep in mind that if the `password:` tag exists without value in an article, it will **not be protected** !
+
+
+### Github secret
+
+Instead of specifying a password in the mkdocs.yml file, you can use a Github secret alongswide with a Github worflow action.
+This requires a requirements.txt in order to install everything required to build the docs.
+
+1. Go to the repo containing the doc you want to protect. Then go to Settings > Secrets > Actions > New repository secret.
+2. Name the secret PASSWORD and specify the the secret value you want to use.
+3. Go to Actions > New worklow > set up a workflow yourself and write the following in the yaml file (name it as you like and take care
+of the requirements.txt path):
+
+```yaml
+name: ci 
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PASSWORD: "${{ secrets.PASSWORD }}"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3.0.2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - name: Deploy
+        run: |
+          pip install -r ./docs/requirements.txt 
+          mkdocs gh-deploy --force
+```
+
+4. Finally, in the mkdocs.yml file, instead of specifying a global password, simply put the `use_secret` field to true:
+
+```yaml
+plugins:
+    - encryptcontent:
+        use_secret: true
+```
+
 
 ### Extra vars customization
 

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -55,6 +55,7 @@ class encryptContentPlugin(BasePlugin):
     config_scheme = (
         # dev: use github secret
         ('use_secret', config_options.Type(bool, default=False)),
+        # _________________________________________________________ #
         ('title_prefix', config_options.Type(string_types, default=str(SETTINGS['title_prefix']))),
         ('summary', config_options.Type(string_types, default=str(SETTINGS['summary']))),
         ('placeholder', config_options.Type(string_types, default=str(SETTINGS['placeholder']))),
@@ -153,8 +154,8 @@ class encryptContentPlugin(BasePlugin):
         :param config: global configuration object (mkdocs.yml)
         :return: global configuration object modified to include templates files
         """
+        # Optionnaly use Github secret 
         if self.config['use_secret']:
-            logger.debug('Using Github secret')
             self.config['global_password'] = os.environ.get('PASSWORD')
         # Set global password as default password for each page
         self.config['password'] = self.config['global_password']

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -53,6 +53,8 @@ class encryptContentPlugin(BasePlugin):
     """ Plugin that encrypt markdown content with AES and inject decrypt form. """
 
     config_scheme = (
+        # dev: use github secret
+        ('use_secret', config_options.Type(bool, default=False)),
         ('title_prefix', config_options.Type(string_types, default=str(SETTINGS['title_prefix']))),
         ('summary', config_options.Type(string_types, default=str(SETTINGS['summary']))),
         ('placeholder', config_options.Type(string_types, default=str(SETTINGS['placeholder']))),
@@ -151,6 +153,9 @@ class encryptContentPlugin(BasePlugin):
         :param config: global configuration object (mkdocs.yml)
         :return: global configuration object modified to include templates files
         """
+        if self.config['use_secret']:
+            logger.debug('Using Github secret')
+            self.config['global_password'] = os.environ.get('PASSWORD')
         # Set global password as default password for each page
         self.config['password'] = self.config['global_password']
         # Check if hljs feature need to be enabled, based on theme configuration

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -53,9 +53,7 @@ class encryptContentPlugin(BasePlugin):
     """ Plugin that encrypt markdown content with AES and inject decrypt form. """
 
     config_scheme = (
-        # dev: use github secret
-        ('use_secret', config_options.Type(bool, default=False)),
-        # _________________________________________________________ #
+        ('use_secret', config_options.Type(string_types, default=None)),
         ('title_prefix', config_options.Type(string_types, default=str(SETTINGS['title_prefix']))),
         ('summary', config_options.Type(string_types, default=str(SETTINGS['summary']))),
         ('placeholder', config_options.Type(string_types, default=str(SETTINGS['placeholder']))),
@@ -154,9 +152,14 @@ class encryptContentPlugin(BasePlugin):
         :param config: global configuration object (mkdocs.yml)
         :return: global configuration object modified to include templates files
         """
-        # Optionnaly use Github secret 
-        if self.config['use_secret']:
-            self.config['global_password'] = os.environ.get('PASSWORD')
+        # Optionnaly use Github secret
+        if self.config.get('use_secret'):
+            if os.environ.get(str(self.config['use_secret'])):
+                self.config['global_password'] = os.environ.get(str(self.config['use_secret']))
+            else:
+                logger.error(('Cannot get global password from environment variable: '),
+                             (f"{str(self.config['use_secret'])}. Abort !"))
+                os.exit()
         # Set global password as default password for each page
         self.config['password'] = self.config['global_password']
         # Check if hljs feature need to be enabled, based on theme configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+beautifulsoup4==4.11.1
+Jinja2==3.1.2
+mkdocs==1.3.0
+pycryptodome==3.14.1
+setuptools==62.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-beautifulsoup4==4.11.1
-Jinja2==3.1.2
-mkdocs==1.3.0
-pycryptodome==3.14.1
-setuptools==62.3.4

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
         '*.tpl.js',
         '*.tpl.html',
         'contrib/templates/search/*.js'
-        ]},
+    ]},
     include_package_data=True
 )


### PR DESCRIPTION
This implements a very minor yet powerful change: 

Using Github actions workflow, it is possible to define a secret password, then make it accessible as an environment variable that the plugin can use instead of writing the expected password directly in the mkdocs.yml file. 
The added description in the README should be pretty straightforward to follow. 

Note that this requires a requirements.txt file in order for the Github worker to build the docs.

Note also that I added some minor changes such as flake8 compliance with smaller max line length (100) and  a .gitignore file. Thoses changes are obviously not required.