### PR TITLE
fix some problems with search index encryption

### DIFF
--- a/encryptcontent/decrypt-contents.tpl.js
+++ b/encryptcontent/decrypt-contents.tpl.js
@@ -98,31 +98,35 @@ function decrypt_search(password_input, path_location) {
         for (var i=0; i < sessionIndex.docs.length; i++) {
             var doc = sessionIndex.docs[i];
             if (doc.location.indexOf(path_location.replace('{{ site_path }}', '')) !== -1) {
+                var parts, content;
                 // grab the ciphertext bundle and try to decrypt it
-                var parts = doc.text.split(';');
+                parts = doc.text.split(';');
                 if (parts[0], parts[1], parts[2]) {
-                    var content = decrypt_content(password_input.value, parts[0], parts[1], parts[2]);
+                    content = decrypt_content(password_input.value, parts[0], parts[1], parts[2]);
+                    if (content) {
+                        doc.text = content;
+                        // any post processing on the decrypted search index should be done here
+                    };
                 };
-                if (content) {
-                    doc.text = content;
-                    // any post processing on the decrypted search index should be done here
-                };
+
                 parts = doc.title.split(';');
                 if (parts[0], parts[1], parts[2]) {
-                    var content = decrypt_content(password_input.value, parts[0], parts[1], parts[2]);
+                    content = decrypt_content(password_input.value, parts[0], parts[1], parts[2]);
+                    if (content) {
+                        doc.title = content;
+                        // any post processing on the decrypted search index should be done here
+                    };
                 };
-                if (content) {
-                    doc.title = content;
-                    // any post processing on the decrypted search index should be done here
-                };
+
                 parts = doc.location.split(';');
                 if (parts[1], parts[2], parts[3]) {
-                    var content = decrypt_content(password_input.value, parts[1], parts[2], parts[3]);
+                    content = decrypt_content(password_input.value, parts[1], parts[2], parts[3]);
+                    if (content) {
+                        doc.location = parts[0] + content;
+                        // any post processing on the decrypted search index should be done here
+                    };
                 };
-                if (content) {
-                    doc.location = parts[0] + content;
-                    // any post processing on the decrypted search index should be done here
-                };
+
             }
         };
         // force search index reloading on Worker

--- a/encryptcontent/decrypt-contents.tpl.js
+++ b/encryptcontent/decrypt-contents.tpl.js
@@ -1,4 +1,4 @@
-/* encryptcontent/decryp-contents.tpl.js */
+/* encryptcontent/decrypt-contents.tpl.js */
 
 /* Strips the padding character from decrypted content. */
 function strip_padding(padded_content, padding_char) {
@@ -97,7 +97,7 @@ function decrypt_search(password_input, path_location) {
         sessionIndex = JSON.parse(sessionIndex);
         for (var i=0; i < sessionIndex.docs.length; i++) {
             var doc = sessionIndex.docs[i];
-            if (doc.location.indexOf(path_location) !== -1) {
+            if (doc.location.indexOf(path_location.replace('{{ site_path }}', '')) !== -1) {
                 // grab the ciphertext bundle and try to decrypt it
                 var parts = doc.text.split(';');
                 if (parts[0], parts[1], parts[2]) {

--- a/encryptcontent/decrypt-contents.tpl.js
+++ b/encryptcontent/decrypt-contents.tpl.js
@@ -107,6 +107,22 @@ function decrypt_search(password_input, path_location) {
                     doc.text = content;
                     // any post processing on the decrypted search index should be done here
                 };
+                parts = doc.title.split(';');
+                if (parts[0], parts[1], parts[2]) {
+                    var content = decrypt_content(password_input.value, parts[0], parts[1], parts[2]);
+                };
+                if (content) {
+                    doc.title = content;
+                    // any post processing on the decrypted search index should be done here
+                };
+                parts = doc.location.split(';');
+                if (parts[1], parts[2], parts[3]) {
+                    var content = decrypt_content(password_input.value, parts[1], parts[2], parts[3]);
+                };
+                if (content) {
+                    doc.location = parts[0] + content;
+                    // any post processing on the decrypted search index should be done here
+                };
             }
         };
         // force search index reloading on Worker

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -240,17 +240,23 @@ class encryptContentPlugin(BasePlugin):
                 from mkdocs.contrib.search.search_index import SearchIndex, ContentParser
                 def _create_entry_for_section(self, section, toc, abs_url, password=None):
                     toc_item, text = self._find_toc_by_id(toc, section.id), ''
+                    title = toc_item.title
+                    toc_url = toc_item.url
                     if not self.config.get('indexing') or self.config['indexing'] == 'full':
                         text = ' '.join(section.text)
                     if password is not None:
                         plugin = config['plugins']['encryptcontent']
                         code = plugin.__encrypt_text_aes__(text, str(password))
                         text = b';'.join(code).decode('ascii')
+                        code = plugin.__encrypt_text_aes__(title, str(password))
+                        title = b';'.join(code).decode('ascii')
+                        code = plugin.__encrypt_text_aes__(toc_url, str(password))
+                        toc_url = ';' + b';'.join(code).decode('ascii')
                     if toc_item is not None:
-                        self._add_entry(title=toc_item.title, text=text, loc=abs_url + toc_item.url)
+                        self._add_entry(title=title, text=text, loc=abs_url + toc_url)
                 SearchIndex.create_entry_for_section = _create_entry_for_section
                 def _add_entry_from_context(self, page):
-                    parser, url, text = ContentParser(), page.url, ''
+                    parser, url, text, title = ContentParser(), page.url, '', page.title
                     parser.feed(page.content)
                     parser.close()
                     use_encryptcontent = (hasattr(page, 'encrypted') and hasattr(page, 'password') and page.password is not None)
@@ -263,10 +269,12 @@ class encryptContentPlugin(BasePlugin):
                     if use_encryptcontent:
                         code = plugin.__encrypt_text_aes__(text, str(page.password))
                         text = b';'.join(code).decode('ascii')
+                        code = plugin.__encrypt_text_aes__(title, str(page.password))
+                        title = b';'.join(code).decode('ascii')
                     if remove_from_search:
                         self._add_entry(title='', text='', loc=url)
                     else:
-                        self._add_entry(title=page.title, text=text, loc=url)
+                        self._add_entry(title=title, text=text, loc=url)
                     if (self.config.get('indexing') and self.config['indexing'] in ['full', 'sections']):
                         for section in parser.data:
                             if not remove_from_search:

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -11,6 +11,7 @@ from Crypto.Cipher import AES
 from bs4 import BeautifulSoup
 from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
+from urllib.parse import urlsplit
 
 try:
     from mkdocs.utils import string_types
@@ -139,6 +140,7 @@ class encryptContentPlugin(BasePlugin):
             'encrypted_something': self.config['encrypted_something'],
             'reload_scripts': self.config['reload_scripts'],
             'experimental': self.config['experimental'],
+            'site_path': self.config['site_path'],
             # add extra vars
             'extra': self.config['js_extra_vars']
         })
@@ -218,6 +220,8 @@ class encryptContentPlugin(BasePlugin):
         if self.config['search_index'] == 'dynamically':
             logger.info('EXPERIMENTAL MODE ENABLE. Only work with default SearchPlugin, not Material.')
             self.config['experimental'] = True
+        # Get path to site in case of subdir in site_url
+        self.config['site_path'] = urlsplit(config.data["site_url"] or '/').path[1::]
 
     def on_pre_build(self, config, **kwargs):
         """

--- a/encryptcontent/plugin.py
+++ b/encryptcontent/plugin.py
@@ -270,7 +270,7 @@ class encryptContentPlugin(BasePlugin):
                 # Overwrite search/*.js files from templates/search with encryptcontent contrib search assets
                 config['theme'].dirs = [
                     e for e in config['theme'].dirs
-                    if not re.compile(r".*/contrib/search/templates$").match(e)
+                    if not re.compile(r".*[/\\]contrib[/\\]search[/\\]templates$").match(e)
                 ]
                 path = os.path.join(base_path, 'contrib/templates')
                 config['theme'].dirs.append(path)


### PR DESCRIPTION
Hi,

even though the default setting when "encryptcontent" and "search" is enabled (`search_index: 'encrypted'`) behaves as described
> encrypted : Search index is encrypted on build. Search is not possible on all encrypted pages.

i think it is a bit anoying that search results of encrypted pages show up (encrypted) because the search term is included in the heading or title (third patch fixes this). And thus removing all encrypted pages from the search index seems better with this mode.

I know it's an experimental feature, but at first the `search_index: 'dynamically'` didn't work at all in my environment (Windows - first patch).

The second problem i encountered (second patch) was that the search index contains 'location' relative to the site root, but in my case window.location.pathname would additionally contain a path different from / (root). To clarify:
```
site_url: https://example.com/foo/          # defined in mkdocs.yml
page_url: https://example.com/foo/bar/      # page in docs/bar.md
```
now this happens in javascript: `window.location.pathname = /foo/bar/`\
but the search index contains a `location = bar/` so it is never decrypted when `decrypt_search` is called.

The last part that I wanted to fix is the leaking of additional information about the encrypted pages, namely the titles of all headings and anchors of the encrypted pages (fourth patch).
